### PR TITLE
feat: 로그인 state 전역관리 및 프로필 수정 시 UI 가 정상적으로 바뀌지 않는 버그 수정

### DIFF
--- a/src/components/header/Icons.tsx
+++ b/src/components/header/Icons.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { getUserInfo } from '../../apis/userInfo';
 
@@ -12,14 +12,21 @@ import Search from './Search';
 import useIsLogin from '../../hooks/useIsLogin';
 import showLoginModal from '../../recoil/showLoginModal';
 import { isLoginAtom } from '../../recoil/profile';
+import { profileImageAtom } from '../../recoil/profile';
 
 const Icons = () => {
   const navigate = useNavigate();
   const isLogin = useRecoilValue(isLoginAtom);
   const setShowLoginModal = useSetRecoilState(showLoginModal);
-
+  const [profileImage, setProfileImage] = useRecoilState(profileImageAtom);
+  
+  //fetch profileImage
   const { data } = useQuery(['userInfo'], getUserInfo);
   const img = data?.data.content.profileImage;
+  useEffect(() => {
+    setProfileImage(img);
+  }, [img]);
+
   const onClickLogin = () => {
     setShowLoginModal(true);
   };
@@ -38,7 +45,7 @@ const Icons = () => {
               navigate('/mypage');
             }}
           >
-            <img src={img} alt="프로필이미지" />
+            <img src={profileImage} alt="프로필이미지" />
           </ProfileImg>
         </>
       ) : (

--- a/src/components/header/Icons.tsx
+++ b/src/components/header/Icons.tsx
@@ -2,19 +2,20 @@ import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { getUserInfo } from '../../apis/userInfo';
 
 import Notification from './Notification';
 import Search from './Search';
 
+import useIsLogin from '../../hooks/useIsLogin';
 import showLoginModal from '../../recoil/showLoginModal';
 import { isLoginAtom } from '../../recoil/profile';
 
 const Icons = () => {
   const navigate = useNavigate();
-  const [isLogin, setIsLogin] = useRecoilState(isLoginAtom);
+  const isLogin = useRecoilValue(isLoginAtom);
   const setShowLoginModal = useSetRecoilState(showLoginModal);
 
   const { data } = useQuery(['userInfo'], getUserInfo);
@@ -23,13 +24,8 @@ const Icons = () => {
     setShowLoginModal(true);
   };
 
-  useEffect(() => {
-    if (window.localStorage.getItem('user')) {
-      setIsLogin(true);
-      return;
-    }
-    setIsLogin(false);
-  }, []);
+  //로그인 확인
+  useIsLogin();
 
   return (
     <IconWrap>

--- a/src/components/header/Icons.tsx
+++ b/src/components/header/Icons.tsx
@@ -24,12 +24,11 @@ const Icons = () => {
   };
 
   useEffect(() => {
-    console.log(window.localStorage.getItem('user'));
     if (window.localStorage.getItem('user')) {
       setIsLogin(true);
-    } else {
-      setIsLogin(false);
+      return;
     }
+    setIsLogin(false);
   }, []);
 
   return (

--- a/src/hooks/useIsLogin.ts
+++ b/src/hooks/useIsLogin.ts
@@ -1,0 +1,17 @@
+import React, { useEffect } from 'react';
+import { useSetRecoilState } from 'recoil';
+
+import { isLoginAtom } from '../recoil/profile';
+
+const useIsLogin = () => {
+  const setIsLogin = useSetRecoilState(isLoginAtom);
+  useEffect(() => {
+    if (window.localStorage.getItem('user')) {
+      setIsLogin(true);
+      return;
+    }
+    setIsLogin(false);
+  }, []);
+};
+
+export default useIsLogin;

--- a/src/pages/Detail/components/comment/CommentContainer.tsx
+++ b/src/pages/Detail/components/comment/CommentContainer.tsx
@@ -19,21 +19,12 @@ type Comment = {
 };
 
 const CommentContainer = ({ id, comment, writer, createdAt, replyNum, userProfileImagePath, page }: Comment) => {
-  // const replyContainerBox = useRef<HTMLDivElement>(null);
   const curSortState = useRecoilValue(sortCommentAtom);
   const [replyIsOpen, setReplyIsOpen] = useState(false);
   const [replyCount, setReplyCount] = useState(replyNum);
   const replyOpenHandler = () => {
     setReplyIsOpen((prev) => !prev);
   };
-  // const scrollDown = () => {
-  //   if (replyContainerBox.current) {
-  //     replyContainerBox.current.scrollTop = replyContainerBox.current.scrollHeight;
-  //   }
-  // };
-  // useEffect(() => {
-  //   scrollDown();
-  // }, [replyIsOpen]);
 
   return (
     <CommentItemContainer>

--- a/src/pages/Detail/components/comment/InputCommentWithPage.tsx
+++ b/src/pages/Detail/components/comment/InputCommentWithPage.tsx
@@ -64,7 +64,6 @@ const InputCommentWithPage = ({ className, placeholder, isLogin }: InputCommentP
 export default InputCommentWithPage;
 
 const InputCommentWrapper = styled(InputComment)`
-  /* display: flex; */
 `;
 
 const InputPageWrapper = styled.div`

--- a/src/pages/Detail/components/comment/ToggleInputComment.tsx
+++ b/src/pages/Detail/components/comment/ToggleInputComment.tsx
@@ -8,7 +8,7 @@ import commentInputHeight from '../../../../recoil/commentInputHeight';
 import upIcon from '../../../../assets/icons/up-bk-24.png';
 import closeIcon from '../../../../assets/icons/close-bk-24.png';
 import writeIcon from '../../../../assets/icons/write_br_24.png';
-
+import { isLoginAtom } from '../../../../recoil/profile';
 
 type inputIsOpenType = {
   inputIsOpen: boolean;
@@ -18,16 +18,17 @@ const ToggleInputComment = () => {
   const inputWrapperRef = useRef<HTMLDivElement>(null);
   const [inputHeight, setInputHeight] = useRecoilState(commentInputHeight);
   const [inputIsOpen, setInputIsOpen] = useState(false);
-  const [isLogin, setIsLogin] = useState<boolean| undefined>();
+  const [isLogin, setIsLogin] =  useRecoilState(isLoginAtom);
 
-  //로그인 유무 확인
+  //초기 로그인 유무 확인
   useEffect(() => {
     const userInfo = window.localStorage.getItem('user');
     userInfo ? setIsLogin(true) : setIsLogin(false);
-  }, [isLogin]);
+  }, []);
 
+  //댓글창 열림 유무에 따른 여백 조절
   useEffect(() => {
-    inputHeight && inputWrapperRef ? setInputHeight(inputWrapperRef.current!.clientHeight) : '';
+    inputHeight && inputWrapperRef.current?.clientHeight ? setInputHeight(inputWrapperRef.current!.clientHeight) : '';
   }, [inputHeight]);
 
   const ToggleInputHandler = () => {

--- a/src/pages/Detail/components/comment/ToggleInputComment.tsx
+++ b/src/pages/Detail/components/comment/ToggleInputComment.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect, useRef } from 'react';
 import styled, { keyframes, css } from 'styled-components';
-import { useRecoilState } from 'recoil';
+import { useRecoilState , useRecoilValue} from 'recoil';
 
 import InputCommentWithPage from './InputCommentWithPage';
 import commentInputHeight from '../../../../recoil/commentInputHeight';
 
-import upIcon from '../../../../assets/icons/up-bk-24.png';
+import useIsLogin from '../../../../hooks/useIsLogin';
 import closeIcon from '../../../../assets/icons/close-bk-24.png';
 import writeIcon from '../../../../assets/icons/write_br_24.png';
 import { isLoginAtom } from '../../../../recoil/profile';
@@ -18,13 +18,10 @@ const ToggleInputComment = () => {
   const inputWrapperRef = useRef<HTMLDivElement>(null);
   const [inputHeight, setInputHeight] = useRecoilState(commentInputHeight);
   const [inputIsOpen, setInputIsOpen] = useState(false);
-  const [isLogin, setIsLogin] =  useRecoilState(isLoginAtom);
+  const isLogin = useRecoilValue(isLoginAtom);
 
-  //초기 로그인 유무 확인
-  useEffect(() => {
-    const userInfo = window.localStorage.getItem('user');
-    userInfo ? setIsLogin(true) : setIsLogin(false);
-  }, []);
+  //로그인 유무 확인
+  useIsLogin();
 
   //댓글창 열림 유무에 따른 여백 조절
   useEffect(() => {
@@ -83,9 +80,7 @@ const CommnetInputContainer = styled.article<inputIsOpenType>`
   bottom: ${(props) => (props.inputIsOpen ? '0px' : '-100px')};
   left: 50%;
   transform: translateX(-50%);
-  /* bottom: 0; */
   width: inherit;
-  /* height: 64px; */
   max-width: 1024px;
   z-index: 100;
   box-shadow: 0px -4px 8px rgba(0, 0, 0, 0.08);

--- a/src/pages/Detail/components/comment/ToggleInputCommentMoblie.tsx
+++ b/src/pages/Detail/components/comment/ToggleInputCommentMoblie.tsx
@@ -2,37 +2,35 @@ import React, { useState, useRef, useEffect } from 'react';
 import styled from 'styled-components';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 
 import InputComment from './InputComment';
 import { postComments } from '../../../../apis/comment';
 import InputPageButton from './InputPageButton';
 import closeIcon from '../../../../assets/icons/close-bk-24.png';
 import writeIcon from '../../../../assets/icons/write_br_24.png';
-import commentInputHeight from '../../../../recoil/commentInputHeight';
+import bookPageAtom from '../../../../recoil/bookPage';
+import { isLoginAtom } from '../../../../recoil/profile';
 
 const ToggelInputCommentMoblie = () => {
-  const maxPage = '524'; //서버에서 받아올 값
+  const bookTotalPage = useRecoilValue(bookPageAtom);
+  const maxPage = bookTotalPage.toString(); 
   const inputWrapperRef = useRef<HTMLDivElement>(null);
-  const [inputHeight, setInputHeight] = useRecoilState(commentInputHeight);
   const [inputIsOpen, setInputIsOpen] = useState(false);
   const [commentContent, setCommentContent] = useState<string>('');
   const [targetPage, setTargetPage] = useState('0');
-  const [isLogin, setIsLogin] = useState<boolean | null>();
+  const [isLogin, setIsLogin] = useRecoilState(isLoginAtom);
+
 
   const queryClient = useQueryClient();
   const params = useParams();
   const isbn = params.id!;
 
+  //로그인 유무 확인
   useEffect(() => {
     const userInfo = window.localStorage.getItem('user');
     userInfo ? setIsLogin(true) : setIsLogin(false);
-  }, [isLogin]);
-
-  // useEffect(() => {
-  //   inputHeight ? setInputHeight(inputWrapperRef.current!.clientHeight) : '';
-  //   // console.log(inputWrapperRef.current?.clientHeight);
-  // }, [inputHeight]);
+  }, []);
 
   const data = {
     content: commentContent,
@@ -48,10 +46,6 @@ const ToggelInputCommentMoblie = () => {
 
   const ToggleInputHandler = () => {
     setInputIsOpen((prev) => !prev);
-    // setTimeout(() => {
-    //   const inputHeight = inputWrapperRef.current?.clientHeight || 1;
-    //   setInputHeight(inputHeight);
-    // }, 1);
   };
 
   const onClickSubmit = () => {

--- a/src/pages/Detail/components/comment/ToggleInputCommentMoblie.tsx
+++ b/src/pages/Detail/components/comment/ToggleInputCommentMoblie.tsx
@@ -2,8 +2,9 @@ import React, { useState, useRef, useEffect } from 'react';
 import styled from 'styled-components';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilValue } from 'recoil';
 
+import useIsLogin from '../../../../hooks/useIsLogin';
 import InputComment from './InputComment';
 import { postComments } from '../../../../apis/comment';
 import InputPageButton from './InputPageButton';
@@ -19,18 +20,14 @@ const ToggelInputCommentMoblie = () => {
   const [inputIsOpen, setInputIsOpen] = useState(false);
   const [commentContent, setCommentContent] = useState<string>('');
   const [targetPage, setTargetPage] = useState('0');
-  const [isLogin, setIsLogin] = useRecoilState(isLoginAtom);
-
+  const isLogin = useRecoilValue(isLoginAtom);
 
   const queryClient = useQueryClient();
   const params = useParams();
   const isbn = params.id!;
 
   //로그인 유무 확인
-  useEffect(() => {
-    const userInfo = window.localStorage.getItem('user');
-    userInfo ? setIsLogin(true) : setIsLogin(false);
-  }, []);
+  useIsLogin();
 
   const data = {
     content: commentContent,

--- a/src/pages/Detail/components/reply/ReplyComments.tsx
+++ b/src/pages/Detail/components/reply/ReplyComments.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import styled from 'styled-components';
+import { useRecoilState } from 'recoil';
 
 import { getReply, postReply } from '../../../../apis/reply';
 import InputComment from '../comment/InputComment';
 import ReplyPagination from './ReplyPagination';
 import CommentItem from '../comment/CommentItem';
+import { isLoginAtom } from '../../../../recoil/profile';
 
 type ReplyPropsType = {
   commentId: string;
@@ -21,18 +23,17 @@ type ReplyType = {
 };
 
 const ReplyComments = ({ commentId, setReplyCount }: ReplyPropsType) => {
-  // ReplyComments.displayName = 'ReplyComments';
   const scrollPoint = useRef<HTMLDivElement>(null);
   const queryClient = useQueryClient();
   const [replyContent, setReplyContent] = useState<string>('');
   const [replyCurPage, setReplyCurPage] = useState<number>(0);
-  const [isLogin, setIsLogin] = useState<boolean|undefined>();
+  const [isLogin, setIsLogin] = useRecoilState(isLoginAtom);
 
   //로그인 확인
   useEffect(() => {
     const userInfo = window.localStorage.getItem('user');
     userInfo ? setIsLogin(true) : setIsLogin(false);
-  }, [isLogin]);
+  }, []);
 
   //getReply
   const size = 5; //고정값

--- a/src/pages/Detail/components/reply/ReplyComments.tsx
+++ b/src/pages/Detail/components/reply/ReplyComments.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import styled from 'styled-components';
-import { useRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 
+import useIsLogin from '../../../../hooks/useIsLogin';
 import { getReply, postReply } from '../../../../apis/reply';
 import InputComment from '../comment/InputComment';
 import ReplyPagination from './ReplyPagination';
@@ -27,13 +28,10 @@ const ReplyComments = ({ commentId, setReplyCount }: ReplyPropsType) => {
   const queryClient = useQueryClient();
   const [replyContent, setReplyContent] = useState<string>('');
   const [replyCurPage, setReplyCurPage] = useState<number>(0);
-  const [isLogin, setIsLogin] = useRecoilState(isLoginAtom);
+  const isLogin = useRecoilValue(isLoginAtom);
 
   //로그인 확인
-  useEffect(() => {
-    const userInfo = window.localStorage.getItem('user');
-    userInfo ? setIsLogin(true) : setIsLogin(false);
-  }, []);
+  useIsLogin();
 
   //getReply
   const size = 5; //고정값

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -14,7 +14,6 @@ type bookImageType = {
 };
 const Detail = () => {
   const bookImage = useRecoilValue(bookImageAtom);
-
   return (
     <MainWrapper bookImage={bookImage}>
       <ContentContainer>

--- a/src/pages/Login/KakaoLogin/index.tsx
+++ b/src/pages/Login/KakaoLogin/index.tsx
@@ -12,7 +12,7 @@ type Code = {
 
 const KakaoOauth = () => {
   const navigate = useNavigate();
-  const setToken = useSetRecoilState(isLoginAtom);
+  const setIsLogin = useSetRecoilState(isLoginAtom);
 
   const [params, setParams] = useSearchParams();
 
@@ -20,7 +20,7 @@ const KakaoOauth = () => {
     onSuccess: (response) => {
       const { id, accessToken, refreshToken, nickname } = response.data;
       window.localStorage.setItem('user', JSON.stringify({ id, accessToken, refreshToken, nickname }));
-      setToken(true);
+      setIsLogin(true);
       navigate('/');
     },
     onError: (e: any) => {

--- a/src/pages/Mypage/components/EditProfileModal.tsx
+++ b/src/pages/Mypage/components/EditProfileModal.tsx
@@ -5,7 +5,7 @@ import { useMutation } from '@tanstack/react-query';
 
 import showEditProfileModal from '../../../recoil/showEditProfileModal';
 import { postProfile } from '../../../apis/profile';
-import { profileAtom } from '../../../recoil/profile';
+import { profileImageAtom } from '../../../recoil/profile';
 
 import Modal from '../../../components/Modal';
 import { ModalPortal } from '../../../components/Modal';
@@ -41,8 +41,9 @@ const img_array = [
 const EditProfileModal = () => {
   const [selectImgIndex, setSelectImgIndex] = useState<number>(0);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const setProfile = useSetRecoilState(profileAtom);
+  const setProfile = useSetRecoilState(profileImageAtom);
 
+  //프로필 이미지 선택 시, 선택된 이미지 중앙으로 위치
   useEffect(() => {
     selectImgIndex && handleItemClick(selectImgIndex);
   }, [selectImgIndex]);
@@ -75,7 +76,9 @@ const EditProfileModal = () => {
   };
 
   const postProfileMutate = useMutation(() => postProfile(profileData), {
-    onSuccess: (response) => setProfile(response.content),
+    onSuccess: (response) => {
+      setProfile(response.content.imagePath);
+    },
     onError: (error) => console.log(error),
   });
 

--- a/src/pages/Mypage/components/Profile.tsx
+++ b/src/pages/Mypage/components/Profile.tsx
@@ -11,19 +11,21 @@ import showLoginModal from '../../../recoil/showLoginModal';
 
 type profileImageType = {
   profileImage: string;
-  isLogin: string | null | undefined;
+  isLogin: boolean;
 };
 
 const Profile = () => {
   const setShowLoginModal = useSetRecoilState(showLoginModal);
-  const setToken = useSetRecoilState(isLoginAtom);
-  const [isLogin, setIsLogin] = useState<string | undefined | null>();
+  const [isLogin, setIsLogin] = useRecoilState(isLoginAtom)
+  const [showProfileModal, setShowEditProfileModal] = useRecoilState(showEditProfileModal);
 
+  //로그인 검증
   useEffect(() => {
     const user = window.localStorage.getItem('user');
-    setIsLogin(user);
-  }, [isLogin]);
+    setIsLogin(!!user);
+  }, []);
 
+  //get Profile
   const { data, refetch } = useQuery({
     queryKey: ['profile', isLogin],
     queryFn: () => getProfile(),
@@ -32,9 +34,7 @@ const Profile = () => {
 
   const { nickname, profileImage } = data || '';
 
-  const [showProfileModal, setShowEditProfileModal] = useRecoilState(showEditProfileModal);
-  const fetchedProfile = useRecoilValue(profileAtom);
-
+  //edit profile modal
   const onShowEditProfile = () => {
     isLogin ? setShowEditProfileModal(true) : alert('로그인 후 이용해주세요');
   };
@@ -43,18 +43,17 @@ const Profile = () => {
     refetch();
   }, [showProfileModal]);
 
+  //login or logout 
   const onClickLogoutBtn = () => {
     if (isLogin) {
       window.localStorage.removeItem('user');
-      setIsLogin(null);
-      setToken(false);
+      setIsLogin(false);
       return;
     }
     setShowLoginModal(true);
   };
 
   return (
-    // login 상태, logout 상태 다르게 보여야됨
     <ProfileWrapper>
       <ProfileImg onClick={onShowEditProfile} profileImage={profileImage} isLogin={isLogin}>
         <SettingIconWrapper>

--- a/src/pages/Mypage/components/Profile.tsx
+++ b/src/pages/Mypage/components/Profile.tsx
@@ -7,7 +7,7 @@ import useIsLogin from '../../../hooks/useIsLogin';
 import showEditProfileModal from '../../../recoil/showEditProfileModal';
 import SettingIcon from '../../../assets/icons/common_setting_gr_16.png';
 import { getProfile } from '../../../apis/profile';
-import { isLoginAtom, profileAtom } from '../../../recoil/profile';
+import { isLoginAtom, profileImageAtom } from '../../../recoil/profile';
 import showLoginModal from '../../../recoil/showLoginModal';
 
 type profileImageType = {
@@ -19,6 +19,7 @@ const Profile = () => {
   const setShowLoginModal = useSetRecoilState(showLoginModal);
   const [isLogin, setIsLogin] = useRecoilState(isLoginAtom)
   const [showProfileModal, setShowEditProfileModal] = useRecoilState(showEditProfileModal);
+  const [profileImage, setProfileImage] = useRecoilState(profileImageAtom);
 
   //로그인 검증
   useIsLogin();
@@ -27,10 +28,13 @@ const Profile = () => {
   const { data, refetch } = useQuery({
     queryKey: ['profile', isLogin],
     queryFn: () => getProfile(),
+    onSuccess: (data) => {
+      setProfileImage(data.profileImage);
+    },
     enabled: !!isLogin,
   });
 
-  const { nickname, profileImage } = data || '';
+  const { nickname } = data || '';
 
   //edit profile modal
   const onShowEditProfile = () => {
@@ -46,6 +50,7 @@ const Profile = () => {
     if (isLogin) {
       window.localStorage.removeItem('user');
       setIsLogin(false);
+      setProfileImage('');
       return;
     }
     setShowLoginModal(true);

--- a/src/pages/Mypage/components/Profile.tsx
+++ b/src/pages/Mypage/components/Profile.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { useQuery } from '@tanstack/react-query';
 
+import useIsLogin from '../../../hooks/useIsLogin';
 import showEditProfileModal from '../../../recoil/showEditProfileModal';
 import SettingIcon from '../../../assets/icons/common_setting_gr_16.png';
 import { getProfile } from '../../../apis/profile';
@@ -20,10 +21,7 @@ const Profile = () => {
   const [showProfileModal, setShowEditProfileModal] = useRecoilState(showEditProfileModal);
 
   //로그인 검증
-  useEffect(() => {
-    const user = window.localStorage.getItem('user');
-    setIsLogin(!!user);
-  }, []);
+  useIsLogin();
 
   //get Profile
   const { data, refetch } = useQuery({

--- a/src/recoil/profile.ts
+++ b/src/recoil/profile.ts
@@ -1,12 +1,10 @@
 import { atom } from 'recoil';
 
-type profileAtomType = {
-  imagePath: string;
-};
-export const profileAtom = atom<profileAtomType>({
-  key: 'profileAtom',
-  default: { imagePath: '' },
+export const profileImageAtom = atom({
+  key: 'profileImageAtom',
+  default: '',
 });
+
 export const isLoginAtom = atom({
   key: 'isLoginAtom',
   default: false,


### PR DESCRIPTION
## 제목
로그인 state 전역관리 하도록 코드 수정

## 관련 이슈
#52 #54 

## 작업 내용
- 로그인 state 전역관리 하고, 모든 컴포넌트에서 초기 렌더링 될 때 로그인 유무를 검증하도록 코드 수정
- 로그인 유무 검증 로직 useIsLogin 커스텀 훅으로 적용 및 사용
- 프로필 수정 직후, 마이페이지와 헤더에서 프로필 이미지 UI 바뀌도록 수정

## 주의 사항